### PR TITLE
Fix build in all versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - luarocks install busted
 
 script:
-  - luacheck . --no-self --ignore /self --globals love getVersion getTitle --std +busted --exclude-files ./lua_install/*
+  - luacheck . --no-self --ignore /self --globals love getVersion getTitle --std max+busted --exclude-files ./lua_install/*
   - busted specs
 
 branches:


### PR DESCRIPTION
This change should fix errors with undeclared global variables in 5.2 and above